### PR TITLE
Containerize Claude Code with custom GHCR image

### DIFF
--- a/.github/workflows/build-claude-image.yml
+++ b/.github/workflows/build-claude-image.yml
@@ -1,0 +1,47 @@
+name: Build Claude Code Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "k8s/claude/docker/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: hiroyaonoe/claude-code
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: k8s/claude/docker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -638,6 +638,8 @@ k8s/
 │       ├── externalsecret-rook-csi-rbd-provisioner.yaml # ExternalSecret
 │       └── externalsecret-rook-csi-rbd-node.yaml      # ExternalSecret
 ├── claude/
+│   ├── docker/
+│   │   └── Dockerfile                          # カスタムイメージ (GHCR にビルド)
 │   └── manifests/
 │       ├── statefulset.yaml                          # StatefulSet + headless Service
 │       ├── service.yaml                              # LoadBalancer Service (SSH)
@@ -976,18 +978,20 @@ kubectl -n monitoring get externalsecret  # SecretSynced=True
 
 ## Claude Code (コンテナ化開発環境)
 
-claude-01 VM を K8s StatefulSet にコンテナ化。永続ストレージ付きの Ubuntu コンテナに SSH でアクセスする。
+claude-01 VM を K8s StatefulSet にコンテナ化。カスタムイメージ + 永続ストレージ付きの Ubuntu コンテナに SSH でアクセスする。
 
 ref: https://github.com/hiroyaonoe/my-network/issues/15
 
 ### アーキテクチャ
 
 ```
+[GHCR] ghcr.io/hiroyaonoe/claude-code:latest
+  └── GitHub Actions: k8s/claude/docker/Dockerfile 変更時にビルド・プッシュ
+
 [StatefulSet] (claude namespace, 1 replica)
-  ├── image: ubuntu:24.04
-  ├── initContainer: rootfs を PVC に rsync (初回のみ)
-  ├── PVC: 32Gi (ceph-block) → / (ルートファイルシステム全体を永続化)
-  ├── command: /usr/sbin/sshd -D
+  ├── image: ghcr.io/hiroyaonoe/claude-code:latest
+  ├── PVC: 32Gi (ceph-block) → /root (ユーザーデータ永続化)
+  ├── command: /usr/sbin/sshd -D -e
   └── port: 22 (SSH)
 
 [Service] claude (headless)
@@ -1010,11 +1014,17 @@ ref: https://github.com/hiroyaonoe/my-network/issues/15
 | CPU | 200m | 2 |
 | Memory | 512Mi | 4Gi |
 
+### イメージビルド
+
+- Dockerfile: `k8s/claude/docker/Dockerfile` (openssh-server 入り Ubuntu 24.04)
+- GitHub Actions: `k8s/claude/docker/**` への push (main) または workflow_dispatch でビルド・プッシュ
+- イメージ: `ghcr.io/hiroyaonoe/claude-code` (タグ: `latest` + `sha-xxxxxxx`)
+- 追加パッケージが必要な場合は Dockerfile に追加してリビルド
+
 ### 永続化の仕組み
 
-- initContainer が Ubuntu rootfs を PVC にコピー (初回のみ、`/rootfs/etc/os-release` の有無で判定)
-- メインコンテナは PVC を `/` にマウントして sshd 起動
-- apt-get でインストールしたパッケージ、設定変更、ユーザーデータは Pod 再起動後も保持
+- PVC を `/root` にマウントし、ユーザーデータ (SSH 鍵、設定ファイル等) を永続化
+- パッケージはカスタムイメージに含める (PVC には含まれない)
 - StatefulSet 削除後も PVC は残る (手動削除が必要)
 
 ### デプロイ (ArgoCD 自動)
@@ -1059,7 +1069,7 @@ nslookup claude.internal.onoe.dev
 
 # 4. PVC
 kubectl -n claude get pvc
-# → rootfs-claude-0  32Gi  Bound
+# → data-claude-0  32Gi  Bound
 
 # 5. SSH 接続
 ssh root@10.5.0.4

--- a/k8s/claude/docker/Dockerfile
+++ b/k8s/claude/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:24.04
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssh-server \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /run/sshd \
+    && sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/k8s/claude/manifests/statefulset.yaml
+++ b/k8s/claude/manifests/statefulset.yaml
@@ -36,40 +36,16 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
-      initContainers:
-        - name: init-rootfs
-          image: ubuntu:24.04
-          command: ["/bin/bash", "-c"]
-          args:
-            - |
-              set -e
-              if [ -f /rootfs/etc/os-release ]; then
-                echo "Root filesystem already initialized, skipping."
-                exit 0
-              fi
-              echo "Initializing root filesystem..."
-              apt-get update
-              apt-get install -y openssh-server rsync
-              rsync -a --exclude='/rootfs' --exclude='/proc' --exclude='/sys' --exclude='/dev' --exclude='/run' / /rootfs/
-              mkdir -p /rootfs/proc /rootfs/sys /rootfs/dev /rootfs/run /rootfs/tmp
-              mkdir -p /rootfs/run/sshd
-              sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /rootfs/etc/ssh/sshd_config
-              echo "Root filesystem initialized."
-          volumeMounts:
-            - name: rootfs
-              mountPath: /rootfs
-          securityContext:
-            runAsUser: 0
       containers:
         - name: claude
-          image: ubuntu:24.04
-          command: ["/usr/sbin/sshd", "-D"]
+          image: ghcr.io/hiroyaonoe/claude-code:latest
+          command: ["/usr/sbin/sshd", "-D", "-e"]
           ports:
             - name: ssh
               containerPort: 22
           volumeMounts:
-            - name: rootfs
-              mountPath: /
+            - name: data
+              mountPath: /root
           resources:
             requests:
               cpu: 200m
@@ -95,7 +71,7 @@ spec:
             runAsUser: 0
   volumeClaimTemplates:
     - metadata:
-        name: rootfs
+        name: data
       spec:
         accessModes:
           - ReadWriteOnce


### PR DESCRIPTION
## What

- Add custom Docker image (`ghcr.io/hiroyaonoe/claude-code`) with openssh-server on Ubuntu 24.04
- Add GitHub Actions workflow to build and push the image to GHCR on `k8s/claude/docker/**` changes
- Deploy as K8s StatefulSet with PVC mounted at `/root` for user data persistence
- Include NetworkPolicies for security isolation (default-deny + allow DNS/SSH/external egress)

## Why

Containerize the Claude Code dev environment (replacing claude-01 VM) to run on the K8s cluster. The previous approach of mounting PVC to `/` with initContainer failed because OCI runtimes (runc) don't allow it. Switched to a custom image approach where packages are baked into the image and only `/root` is persisted via PVC.

## Ref

- #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)