### PR TITLE
Fix Sshwifty secret volume permissions

### DIFF
--- a/k8s/sshwifty/manifests/deployment.yaml
+++ b/k8s/sshwifty/manifests/deployment.yaml
@@ -70,7 +70,8 @@ spec:
         - name: secrets
           secret:
             secretName: sshwifty-secrets
-            defaultMode: 0400
+            defaultMode: 0444
         - name: tls
           secret:
             secretName: sshwifty-tls
+            defaultMode: 0444


### PR DESCRIPTION
## What

- Change `sshwifty-secrets` volume defaultMode from `0400` to `0444`
- Add explicit `defaultMode: 0444` to `sshwifty-tls` volume

## Why

Sshwifty runs as a non-root user and cannot read files with mode `0400` (owner-only). This caused `permission denied` when loading the SSH private key.

## Ref

- #42
- #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)