### PR TITLE
Switch Sshwifty probes from tcpSocket to HTTPS

### DIFF
--- a/k8s/sshwifty/manifests/deployment.yaml
+++ b/k8s/sshwifty/manifests/deployment.yaml
@@ -56,12 +56,16 @@ spec:
               cpu: 500m
               memory: 128Mi
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /
               port: http
+              scheme: HTTPS
             periodSeconds: 10
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /
               port: http
+              scheme: HTTPS
             periodSeconds: 30
       volumes:
         - name: config


### PR DESCRIPTION
## What

- Change readinessProbe and livenessProbe from `tcpSocket` to `httpGet` with `scheme: HTTPS`

## Why

tcpSocket probes open a TCP connection without completing TLS handshake, causing noisy `DEF` log entries (`TLS handshake error: EOF`) every 10/30 seconds.

## Ref

- #42
- #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)